### PR TITLE
FMV向け、pyinstallerで実行することを前提としたFirmware config設定用スクリプト追加

### DIFF
--- a/actcast_api/actcast_api.py
+++ b/actcast_api/actcast_api.py
@@ -204,7 +204,6 @@ class ActcastAPI:
         return res
 
     # イベントログ取得
-
     @api_request_exception
     def get_event_log(self, groupid, deviceid, query_params=""):
         endpoint = self.actcast.groups(groupid).devices(deviceid).event_logs
@@ -212,11 +211,26 @@ class ActcastAPI:
 
         return res
 
-    # ファームウェア詳細
+    # Actログ取得
+    @api_request_exception
+    def get_act_log(self, groupid, deviceid, query_params=""):
+        endpoint = self.actcast.groups(groupid).devices(deviceid).act_logs
+        res = endpoint.get(params=query_params)
 
+        return res
+
+    # ファームウェア詳細
     @api_request_exception
     def get_firmware_info(self, group_id, query_params=""):
         endpoint = self.actcast.groups(group_id).firmwares
+        res = endpoint.get(params=query_params)
+
+        return res
+
+    # 最新FW Ver取得
+    @api_request_exception
+    def get_latest_firmware_version(self, group_id, query_params=""):
+        endpoint = self.actcast.groups(group_id).firmwares.raspberrypi.versions
         res = endpoint.get(params=query_params)
 
         return res

--- a/get_latest_firmware_version.py
+++ b/get_latest_firmware_version.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import ast
+import json
+from actcast_api import ActcastAPI
+
+
+def get_latest_firmware_version(api, group_id):
+
+    # Request
+    data = api.get_latest_firmware_version(group_id)
+
+    # Print result
+    # actcast_api Wrapperの戻り値は正式なJSON形式で返ってこない(シングルクォーテーションが使われている)
+    # なので、一旦辞書型にしてからjsonモジュールで扱う
+    data = ast.literal_eval(str(data))
+    print(json.dumps(data, indent=2))
+
+
+if __name__ == '__main__':
+    api = ActcastAPI()
+
+    args = sys.argv
+    if len(args) < 2:
+        print("usage:")
+        print(f"$ python3 {os.path.basename(__file__)} group_id")
+    else:
+        get_latest_firmware_version(api, args[1])

--- a/pyinstaller/Readme.txt
+++ b/pyinstaller/Readme.txt
@@ -1,0 +1,22 @@
+Pythonスクリプトの利用が難しい方向けに、
+Pyinstallerを使って実行ファイル(Win/Mac向け)を生成する方法メモ
+
+【経緯】
+FMVプロジェクトで発生したFW1.6.0でのインシデントを受け、
+Firmware ConfigによってFirmware Versionを固定する運用に変更予定。
+update_firmware_config_from_list.pyをベースに、
+コマンドラインの操作が不要な
+update_firmware_config_for_fmv.py
+を作成し、pyinstallerで実行ファイル化する。
+運用想定者がWin/Macの両方あるため、それぞれの端末上でコンパイルして配布する
+
+【pipenvを使って仮想環境を作成】
+インストールが必要なライブラリは以下の通り
+・requests
+・tortilla
+
+【pyinstallerで実行ファイル作成】
+pyinstaller [スクリプト] --onefile
+
+※参考にしたサイト
+https://camp.trainocate.co.jp/magazine/pyinstaller-python-exe/

--- a/update_firmware_config_for_fmv.py
+++ b/update_firmware_config_for_fmv.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+import os
+from os import path
+import sys
+import time
+import datetime
+import logging
+import ast
+from actcast_api import ActcastAPI, Color
+from logging import StreamHandler, FileHandler, Formatter
+from logging import INFO, DEBUG, NOTSET
+
+request_interval_msec = 500
+
+GROUP_ID = 2121
+ID_LIST_NAME = "device_list.txt"
+
+
+def update_firmware_config_from_list(api, target_firmware_version):
+
+    print_current_fw_info(api, GROUP_ID)
+
+    update_fw_config(api, GROUP_ID, ID_LIST_NAME, target_firmware_version)
+
+    logging.info('=' * 80)
+    logging.info(f'Done. {datetime.datetime.now()}(JST)')
+
+    input("Press any key to exit...")
+
+
+def update_fw_config(api, group_id, id_list_name, target_firmware_version):
+    with open(id_list_name) as f:
+        while True:
+            current_device_id = f.readline()
+            if current_device_id == '':
+                break
+
+            update_single(api, group_id, current_device_id.rstrip(),
+                          target_firmware_version)
+
+
+def update_single(api, group_id, device_id, target_firmware_version):
+    time.sleep(request_interval_msec / 1000)
+
+    firmware_config = {"firmware_config": {
+        "firmware_version": {
+            "firmware_version": target_firmware_version,
+            "type": "fixed"
+        }
+    }}
+
+    item = api.set_device_settings(group_id, device_id, firmware_config)
+
+    if item is False:
+        logging.error(
+            Color.RED + f'└> ERROR updating Firmware for device: {device_id}')
+        logging.error('-' * 80, Color.COLOR_DEFAULT)
+    else:
+        logging.info(f'{device_id}')
+
+
+def print_current_fw_info(api, group_id):
+    latest_info = api.get_firmware_info(group_id).items[0]
+    release_date = api.iso8601toJST(latest_info.release_date)
+    logging.info('Latest firmware')
+    logging.info(f'firmware_type    : {latest_info.firmware_type}')
+    logging.info(f'firmware_version : {latest_info.firmware_version}')
+    logging.info(f'release_date     : {release_date}(JST)')
+    logging.info('=' * 50)
+    logging.info(f'Start. {datetime.datetime.now()}(JST)')
+
+
+if __name__ == '__main__':
+    # ログ出力用ストリームハンドラの設定
+    stream_handler = StreamHandler()
+    stream_handler.setLevel(INFO)
+    stream_handler.setFormatter(Formatter("%(message)s"))
+
+    # ログファイル保存先の有無チェック
+    if not os.path.isdir('./Log'):
+        os.makedirs('./Log', exist_ok=True)
+
+    # ファイルハンドラの設定
+    file_handler = FileHandler(
+        f"./Log/update_firmware_from_list_{datetime.datetime.now():%Y%m%d%H%M%S}.log"
+    )
+    file_handler.setLevel(DEBUG)
+    file_handler.setFormatter(
+        Formatter(
+            "%(asctime)s@ %(name)s [%(levelname)s] %(funcName)s: %(message)s")
+    )
+    logging.basicConfig(level=NOTSET, handlers=[stream_handler, file_handler])
+
+    api = ActcastAPI()
+
+    target_firmware_version = input("specify firmware version for firmware config: ")
+    update_firmware_config_from_list(api, target_firmware_version)

--- a/update_firmware_config_from_list.py
+++ b/update_firmware_config_from_list.py
@@ -9,7 +9,6 @@ import ast
 from actcast_api import ActcastAPI, Color
 from logging import StreamHandler, FileHandler, Formatter
 from logging import INFO, DEBUG, NOTSET
-from actcast_api.device_settings_template import DeviceSettingTags, DeviceSettingTemplateGenerator
 
 request_interval_msec = 500
 


### PR DESCRIPTION
Ver1.6.0で発生した、ネットワークが普通になるインシデントに起因して、
FMVのプロジェクトでFirmware Versionの固定による段階的なFW更新の運用を実現する必要がある。
https://idein-inc.slack.com/archives/C03BTDZMDB4/p1671608963237529?thread_ts=1671505517.171669&cid=C03BTDZMDB4
https://idein-inc.slack.com/archives/CEP26P3S5/p1671703042489139?thread_ts=1671598313.942149&cid=CEP26P3S5

設定者のリテラシーにかかわらずスクリプトを実行できるようにするため、
Win/Mac用の実行ファイルをpyinstallerで作成出来るように手順等を整備